### PR TITLE
Gating go to specific version

### DIFF
--- a/org-inherited-config.json
+++ b/org-inherited-config.json
@@ -9,7 +9,7 @@
       "matchDepTypes": ["*"],
       "groupName": "Go Dependencies",
       "groupSlug": "go-deps",
-      "allowedVersions": "<1.24.0"
+      "allowedVersions": "<=1.23.4"
     },
     {
       "description": ["Group all Docker image updates together"],


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Restrict Go tooling to the specified version in org-inherited-config.json