### PR TITLE
Ignoring default groupings

### DIFF
--- a/org-inherited-config.json
+++ b/org-inherited-config.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "labels": ["dependencies"],
-  "ignorePresets": ["config:recommended"],
+  "ignorePresets": ["config:recommended","group:recommended","group:monorepo"],
   "enabledManagers": ["dockerfile", "npm","pip_requirements","gomod","cargo"],
   "packageRules": [
     {
@@ -67,7 +67,8 @@
         "matchDepTypes": [
           "indirect"
         ],
-        "enabled": true
+        "enabled": true,
+        "allowedVersions": "<=1.23.4"
       }
     ]
   },


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Skip over default grouping entries when parsing org-inherited-config.json