### PR TITLE
Gating to go v1.23.6

### DIFF
--- a/org-inherited-config.json
+++ b/org-inherited-config.json
@@ -10,7 +10,7 @@
       "matchDepTypes": ["*"],
       "groupName": "Go Dependencies",
       "groupSlug": "go-deps",
-      "allowedVersions": "<=1.23.4"
+      "allowedVersions": "<=1.23.6"
     },
     {
       "description": ["Group all Docker image updates together"],
@@ -57,7 +57,7 @@
   "gomod": {
     "postUpdateOptions": [
       "gomodUpdateImportPaths",
-      "gomodTidy"
+      "gomodTidy1.23.6"
     ],
   "packageRules": [
       {
@@ -68,7 +68,7 @@
           "indirect"
         ],
         "enabled": true,
-        "allowedVersions": "<=1.23.4"
+        "allowedVersions": "<=1.23.6"
       }
     ]
   },


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Bump Go version requirement to v1.23.6 in org-inherited-config.json