### PR TITLE
Limit version of go docker container to 1.23

### DIFF
--- a/org-inherited-config.json
+++ b/org-inherited-config.json
@@ -45,7 +45,8 @@
       ],
       "matchPackageNames": [
         "golang"
-      ]
+      ],
+      "allowedVersions": "<1.24.0"
     },
     {
       "matchDatasources": [


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Pin Go Docker container version to 1.23 in org-inherited-config.json